### PR TITLE
Fix: Improve preview branch sync after deployment

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Wait for deployment
         if: steps.check-prs.outputs.result != 'no-prs'
-        run: sleep 30
+        run: sleep 60
 
       - name: Merge main back to preview
         if: steps.check-prs.outputs.result != 'no-prs'
@@ -149,15 +149,25 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action" 
 
+          # Ensure we have the latest main branch
+          git fetch origin main
+          
           # Switch to preview branch
           git checkout preview
           git pull origin preview
 
-          # Merge main into preview
-          git merge origin/main --no-ff -m "Sync preview with main after deployment"
-
-          # Push updated preview
-          git push origin preview
+          # Check if there are differences between preview and main
+          if git diff --quiet preview origin/main; then
+            echo "Preview and main are already in sync"
+          else
+            echo "Merging main into preview..."
+            # Merge main into preview
+            git merge origin/main --no-ff -m "Sync preview with main after deployment"
+            
+            # Push updated preview
+            git push origin preview
+            echo "Successfully synced preview with main"
+          fi
 
       - name: Comment on merged PRs
         if: steps.check-prs.outputs.result != 'no-prs'


### PR DESCRIPTION
## 🔧 Improvement

This PR improves the preview branch synchronization process after scheduled deployments.

### Problem
The workflow was showing 'Already up to date' when trying to merge main back into preview, but the branches weren't actually synchronized properly, requiring manual intervention.

### Root Cause
- Insufficient wait time for deployment to complete
- No explicit fetch of latest main branch before merging
- No verification if branches are actually in sync

### Solution
- **Increased wait time**: 30s → 60s for deployment to complete
- **Explicit main fetch**: Ensure we have the latest main branch
- **Sync verification**: Check if preview and main are actually different
- **Conditional merge**: Only attempt merge if there are real differences
- **Better logging**: Clear messages about what's happening

### Changes
- ✅ Longer wait time for deployment completion
- ✅ Explicit `git fetch origin main` before merge
- ✅ `git diff` check to verify if merge is needed
- ✅ Conditional merge logic with proper logging
- ✅ Prevents unnecessary merge attempts

### Impact
This should fix the issue where the workflow appeared to complete successfully but the preview branch wasn't properly synchronized with main after deployment.