### PR TITLE
[feat-33]: Add click-outside detection for mobile tooltips

### DIFF
--- a/src/components/MobileTooltip.tsx
+++ b/src/components/MobileTooltip.tsx
@@ -30,7 +30,7 @@ export function MobileTooltip({
   offset = 8,
   ...props
 }: MobileTooltipProps) {
-  const { opened, handlers } = useMobileTooltip({
+  const { opened, handlers, ref } = useMobileTooltip({
     delay,
     disabled,
     trigger,
@@ -69,6 +69,7 @@ export function MobileTooltip({
   return (
     <Tooltip {...tooltipProps}>
       <span
+        ref={ref}
         {...handlers}
         className="mobile-tooltip-wrapper"
         style={{

--- a/src/hooks/useMobileTooltip.ts
+++ b/src/hooks/useMobileTooltip.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 interface UseMobileTooltipOptions {
   delay?: number;
@@ -16,6 +16,7 @@ interface UseMobileTooltipReturn {
     onTouchEnd: () => void;
     onClick: () => void;
   };
+  ref: React.RefObject<HTMLElement | null>;
 }
 
 /**
@@ -29,6 +30,7 @@ export function useMobileTooltip({
 }: UseMobileTooltipOptions = {}): UseMobileTooltipReturn {
   const [opened, setOpened] = useState(false);
   const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout | null>(null);
+  const ref = useRef<HTMLElement>(null);
 
   // Note: Hover detection removed as it's not currently used
   // but can be re-added if needed for future enhancements
@@ -99,6 +101,26 @@ export function useMobileTooltip({
     }
   }, [trigger, toggleTooltip]);
 
+  // Handle click outside to close tooltip
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (opened && ref.current && !ref.current.contains(event.target as Node)) {
+        closeTooltip();
+      }
+    };
+
+    if (opened) {
+      // Add event listeners for both mouse and touch events
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('touchstart', handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [opened, closeTooltip]);
+
   // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
@@ -116,5 +138,6 @@ export function useMobileTooltip({
       onTouchEnd: handleTouchEnd,
       onClick: handleClick,
     },
+    ref,
   };
 }

--- a/src/hooks/useMobileTooltip.ts
+++ b/src/hooks/useMobileTooltip.ts
@@ -104,7 +104,7 @@ export function useMobileTooltip({
   // Handle click outside to close tooltip
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-      if (opened && ref.current && !ref.current.contains(event.target as Node)) {
+      if (opened && ref.current && event.target && !ref.current.contains(event.target as Node)) {
         closeTooltip();
       }
     };


### PR DESCRIPTION
# Pull Request

## 📝 Title Format

`[feat-33]: Add click-outside detection for mobile tooltips`

## 🎯 Summary

This PR implements click-outside detection for mobile tooltips to improve the mobile user experience. Previously, mobile tooltips would stay open until manually closed, creating a poor UX. Now tooltips automatically close when users tap elsewhere on the screen.

## 📋 Changes

- [x] Enhanced useMobileTooltip hook with click-outside detection
- [x] Added ref support for element tracking in MobileTooltip component
- [x] Implemented document-level event listeners for both mousedown and touchstart events
- [x] Added proper event cleanup to prevent memory leaks
- [x] Maintained backward compatibility with existing tooltip functionality
- [x] Added TypeScript types and error handling

## 🧪 How to Test

### Quick Test

```bash
npm run build && npm run dev
```

### Manual Testing

- [x] Build passes without errors
- [x] Feature works as expected
- [x] No console errors
- [x] Responsive design works
- [x] Cross-browser compatibility

### Preview Deployment Testing

- [ ] Preview deployment is accessible and working
- [ ] All new features function correctly on preview
- [ ] No regressions in existing functionality
- [ ] Performance is acceptable on preview environment

### Specific to this PR

- [ ] Open the portfolio on a mobile device or mobile browser dev tools
- [ ] Tap on any tooltip trigger (question mark icons, badges, etc.)
- [ ] Verify tooltip opens correctly
- [ ] Tap elsewhere on the screen and verify tooltip closes automatically
- [ ] Test with multiple tooltips to ensure they all work independently

## 🔗 Related

- Closes #33

## ✅ Ready

- [x] Code reviewed
- [x] Tests pass
- [x] No breaking changes