### PR TITLE
Update cron schedule for daily deployment to be daily at 9

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -2,7 +2,7 @@ name: Scheduled Daily Deploy
 
 on:
   schedule:
-    - cron: '0 14 * * 1-5' # 2:00 PM UTC (9:00 AM EST), Monday-Friday
+    - cron: '0 13 * * 0-6' # 1:00 PM UTC (9:00 AM EST), Daily
   workflow_dispatch: # Manual trigger
 
 permissions:


### PR DESCRIPTION
Instead of Monday through Friday at 10

# Pull Request

## 📝 Title Format

`[N/A]: Update cron schedule for daily deployment to be daily at 9`

**Types:**

- `feat` - New features
- `fix` - Bug fixes
- `refactor` - Code improvements

**Examples:**

- `[feat-123]: Add user authentication system`
- `[fix-456]: Resolve modal header layout issues`
- `[refactor-789]: Update CI/CD workflow automation`

## 🎯 Summary

Brief description of what this PR accomplishes.

## 📋 Changes

- [ ] Fixed time being 10am to 1pm UTC which is 9am
- [ ] Changed from Monday to friday to Daily

## 🧪 How to Test

Check github actions and make sure the deployment ran.
Check main locally.

### Quick Test

N/A

### Manual Testing

N/A

### Preview Deployment Testing

N/A

### Specific to this PR

N/A

## 🔗 Related

N/A

## ✅ Ready

- [ ] Code reviewed
- [ ] Tests pass
- [ ] No breaking changes
