### PR TITLE
[BBG-48] Improve homepage Lighthouse performance and SEO signals

### DIFF
--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -76,7 +76,7 @@ This repository includes comprehensive GitHub Actions workflows for automated te
 - Vercel Preview deployment Lighthouse checks after successful preview deployments
 - Core Web Vitals monitoring
 - PR comments with performance scores and workflow artifact/report context
-- Vercel Preview checks use the `VERCEL_AUTOMATION_BYPASS_SECRET` Actions secret with Vercel Protection Bypass for Automation and the bypass-cookie header so Lighthouse audits the deployed app instead of the Vercel authentication shell
+- Vercel Preview checks use the `VERCEL_AUTOMATION_BYPASS_SECRET` Actions secret with Vercel Protection Bypass for Automation and fail fast if the response is still the Vercel authentication shell
 - Lighthouse report uploads use the Lighthouse action `resultsPath` output so HTML/JSON artifacts are collected from the actual generated results directory
 
 ### 7. Dependency Updates (`dependabot.yml`)

--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -77,6 +77,8 @@ This repository includes comprehensive GitHub Actions workflows for automated te
 - Core Web Vitals monitoring
 - PR comments with performance scores and workflow artifact/report context
 - Vercel Preview checks use the `VERCEL_AUTOMATION_BYPASS_SECRET` Actions secret with Vercel Protection Bypass for Automation and fail fast if the response is still the Vercel authentication shell
+- Vercel Preview checks verify that Lighthouse CI is configured with the bypass header before the audit starts
+- A preview `x-robots-tag: noindex` header is reported as a notice because Vercel may add it to preview deployments even when the app is reachable
 - Lighthouse report uploads use the Lighthouse action `resultsPath` output so HTML/JSON artifacts are collected from the actual generated results directory
 
 ### 7. Dependency Updates (`dependabot.yml`)

--- a/.github/GITHUB_ACTIONS.md
+++ b/.github/GITHUB_ACTIONS.md
@@ -76,7 +76,7 @@ This repository includes comprehensive GitHub Actions workflows for automated te
 - Vercel Preview deployment Lighthouse checks after successful preview deployments
 - Core Web Vitals monitoring
 - PR comments with performance scores and workflow artifact/report context
-- Vercel Preview checks use the `VERCEL_AUTOMATION_BYPASS_SECRET` Actions secret with Vercel Protection Bypass for Automation so Lighthouse audits the deployed app instead of the Vercel login redirect
+- Vercel Preview checks use the `VERCEL_AUTOMATION_BYPASS_SECRET` Actions secret with Vercel Protection Bypass for Automation and the bypass-cookie header so Lighthouse audits the deployed app instead of the Vercel authentication shell
 - Lighthouse report uploads use the Lighthouse action `resultsPath` output so HTML/JSON artifacts are collected from the actual generated results directory
 
 ### 7. Dependency Updates (`dependabot.yml`)

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -195,7 +195,6 @@ jobs:
           header_args=()
           if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
             header_args+=(--header "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
-            header_args+=(--header "x-vercel-set-bypass-cookie: true")
           else
             echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is not configured; Lighthouse would audit the Vercel authentication shell instead of the deployed app."
             exit 1

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -195,17 +195,31 @@ jobs:
           header_args=()
           if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
             header_args+=(--header "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}")
+            header_args+=(--header "x-vercel-set-bypass-cookie: true")
           else
-            echo "::warning::VERCEL_AUTOMATION_BYPASS_SECRET is not configured; preflight will run without bypass headers."
+            echo "::error::VERCEL_AUTOMATION_BYPASS_SECRET is not configured; Lighthouse would audit the Vercel authentication shell instead of the deployed app."
+            exit 1
           fi
 
-          final_url="$(curl -LsS -o /dev/null -w '%{url_effective}' "${header_args[@]}" "${DEPLOYMENT_URL}")"
+          preflight_response="$(mktemp)"
+          preflight_headers="$(mktemp)"
+          final_url="$(curl -LsS -D "${preflight_headers}" -o "${preflight_response}" -w '%{url_effective}' "${header_args[@]}" "${DEPLOYMENT_URL}")"
 
           echo "Requested deployment URL: ${DEPLOYMENT_URL}"
           echo "Final deployment URL: ${final_url}"
 
           if [[ "${final_url}" == https://vercel.com/login* || "${final_url}" == *"//vercel.com/login"* ]]; then
             echo "::error::Vercel preview URL resolved to a login redirect. Configure VERCEL_AUTOMATION_BYPASS_SECRET for Lighthouse automation."
+            exit 1
+          fi
+
+          if grep -iq '^x-robots-tag:.*noindex' "${preflight_headers}"; then
+            echo "::error::Vercel preview response still includes x-robots-tag: noindex, which indicates deployment protection was not bypassed."
+            exit 1
+          fi
+
+          if grep -qi 'Vercel Authentication' "${preflight_response}"; then
+            echo "::error::Vercel preview response still contains the Vercel Authentication shell instead of the app."
             exit 1
           fi
 

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -91,6 +91,17 @@ jobs:
               .readdirSync(resultsPath)
               .filter(file => file.endsWith('.json'));
 
+            const manifestPath = path.join(resultsPath, 'manifest.json');
+            const representativeJsonFile = fs.existsSync(manifestPath)
+              ? JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+                  .find(entry => entry.isRepresentativeRun)
+                  ?.jsonPath?.split(/[\\/]/)
+                  .pop()
+              : null;
+            if (representativeJsonFile && jsonFiles.includes(representativeJsonFile)) {
+              jsonFiles.sort(file => (file === representativeJsonFile ? -1 : 1));
+            }
+
             for (const file of jsonFiles) {
               const result = JSON.parse(fs.readFileSync(path.join(resultsPath, file), 'utf8'));
               const lhr = result.lhr || result;
@@ -283,6 +294,17 @@ jobs:
               .readdirSync(resultsPath)
               .filter(file => file.endsWith('.json'));
 
+            const manifestPath = path.join(resultsPath, 'manifest.json');
+            const representativeJsonFile = fs.existsSync(manifestPath)
+              ? JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+                  .find(entry => entry.isRepresentativeRun)
+                  ?.jsonPath?.split(/[\\/]/)
+                  .pop()
+              : null;
+            if (representativeJsonFile && jsonFiles.includes(representativeJsonFile)) {
+              jsonFiles.sort(file => (file === representativeJsonFile ? -1 : 1));
+            }
+
             for (const file of jsonFiles) {
               const result = JSON.parse(fs.readFileSync(path.join(resultsPath, file), 'utf8'));
               const lhr = result.lhr || result;
@@ -298,6 +320,7 @@ jobs:
               const lcp = auditNumber('largest-contentful-paint');
               const fid = auditNumber('max-potential-fid');
               const cls = auditNumber('cumulative-layout-shift');
+              const isCrawlableAudit = lhr.audits['is-crawlable'];
               const requestedDeployment = context.payload.deployment_status?.environment_url || 'Not reported';
               const finalAuditedUrl = lhr.finalDisplayedUrl || lhr.finalUrl || 'Not reported';
               const runUrl =
@@ -328,6 +351,18 @@ jobs:
 
               if (runUrl) {
                 commentLines.push(`- **Workflow run**: [View run details](${runUrl})`);
+              }
+
+              if (
+                isCrawlableAudit?.score === 0 &&
+                typeof finalAuditedUrl === 'string' &&
+                finalAuditedUrl.includes('.vercel.app')
+              ) {
+                commentLines.push(
+                  '',
+                  '### SEO Note',
+                  '- **Vercel Preview noindex**: Lighthouse reports this preview URL as blocked from indexing. Local production Lighthouse reports app-level SEO separately.'
+                );
               }
 
               commentLines.push('- **Full Lighthouse reports**: Attached to this workflow run as artifacts (HTML + JSON).');

--- a/.github/workflows/performance-monitor.yml
+++ b/.github/workflows/performance-monitor.yml
@@ -213,14 +213,19 @@ jobs:
           fi
 
           if grep -iq '^x-robots-tag:.*noindex' "${preflight_headers}"; then
-            echo "::error::Vercel preview response still includes x-robots-tag: noindex, which indicates deployment protection was not bypassed."
-            exit 1
+            echo "::notice::Vercel preview response includes x-robots-tag: noindex. Continuing because preview deployments may include this header even when the app is reachable."
           fi
 
           if grep -qi 'Vercel Authentication' "${preflight_response}"; then
-            echo "::error::Vercel preview response still contains the Vercel Authentication shell instead of the app."
+            echo "::error::Vercel preview response still contains the Vercel Authentication shell instead of the app. Confirm the GitHub Actions VERCEL_AUTOMATION_BYPASS_SECRET exactly matches the current Vercel Protection Bypass for Automation secret and redeploy after any secret rotation."
             exit 1
           fi
+
+      - name: Verify Lighthouse bypass header configuration
+        env:
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+        run: |
+          node -e "const config = require('./lighthouserc.cjs'); const rawHeaders = config?.ci?.collect?.settings?.extraHeaders; const headers = typeof rawHeaders === 'string' ? JSON.parse(rawHeaders) : rawHeaders || {}; if (headers['x-vercel-protection-bypass'] !== process.env.VERCEL_AUTOMATION_BYPASS_SECRET) { throw new Error('Lighthouse config is missing the Vercel protection bypass header.'); } console.log('Lighthouse config includes the Vercel protection bypass header.');"
 
       - name: Run Lighthouse CI
         id: lighthouse

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -7,7 +7,6 @@ const collectSettings = {
 if (automationBypassSecret) {
   collectSettings.extraHeaders = JSON.stringify({
     'x-vercel-protection-bypass': automationBypassSecret,
-    'x-vercel-set-bypass-cookie': 'true',
   });
 }
 

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -7,6 +7,7 @@ const collectSettings = {
 if (automationBypassSecret) {
   collectSettings.extraHeaders = JSON.stringify({
     'x-vercel-protection-bypass': automationBypassSecret,
+    'x-vercel-set-bypass-cookie': 'true',
   });
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,7 @@ const inter = localFont({
   ],
   display: 'swap',
   fallback: ['system-ui', 'Arial', 'sans-serif'],
+  preload: false,
   variable: '--font-inter',
 });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,10 +4,10 @@ import {
   LazyAboutSection,
   LazyContactSection,
   LazyExperienceSection,
-  LazyHeroSection,
   LazyWatchSection,
   LazyWorkSection,
 } from '@/components/LazyComponents';
+import HeroSection from '@/components/HeroSection';
 import ParallaxElement from '@/components/ParallaxElement';
 import { ModalProvider } from '@/lib/modal-context';
 import { getSectionSpeed } from '@/lib/parallax-config';
@@ -24,7 +24,7 @@ const HomePage = memo(() => {
     <ModalProvider>
       <ParallaxProvider>
         {/* Hero Section */}
-        <LazyHeroSection />
+        <HeroSection />
 
         <ParallaxElement speed={getSectionSpeed('watch')}>
           <Box

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -186,7 +186,7 @@ const AboutSection = memo(() => {
         {/* Hero Section */}
         <Box ta="center" mb="xl">
           <Title
-            order={1}
+            order={2}
             size="h1"
             mb="md"
             style={{

--- a/src/components/BrandLogo.tsx
+++ b/src/components/BrandLogo.tsx
@@ -51,6 +51,7 @@ export default function BrandLogo({
         alt={alt}
         width={1208}
         height={530}
+        loading="lazy"
         style={{
           display: 'block',
           width: '100%',

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -121,7 +121,7 @@ const ContactSection = memo(() => {
         {/* Header */}
         <Box ta="center" mb="xl">
           <Title
-            order={1}
+            order={2}
             size="h1"
             mb="md"
             style={{

--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -32,7 +32,7 @@ const ExperienceSection = memo(() => {
         {/* Header */}
         <Box ta="center" mb="xl">
           <Title
-            order={1}
+            order={2}
             size="h1"
             mb="md"
             style={{

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,7 @@ import ThemeModeSelector from './ThemeModeSelector';
 import ThemeToggle from './ThemeToggle';
 
 const HEADER_HEIGHT = 60;
+const HEADER_Z_INDEX = 1100;
 
 interface HeaderProps {
   links: Array<{ link: string; label: string }>;
@@ -40,7 +41,8 @@ export default function Header({ links }: HeaderProps) {
       setScrolled(window.scrollY > 20);
     };
 
-    window.addEventListener('scroll', handleScroll);
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 
@@ -79,7 +81,7 @@ export default function Header({ links }: HeaderProps) {
         top: 0,
         left: 0,
         right: 0,
-        zIndex: 100,
+        zIndex: HEADER_Z_INDEX,
         transition: 'all 0.3s ease',
         background: scrolled
           ? withOpacity(warmColors[0] ?? '#FDFCFB', 0.95)

--- a/src/components/LazyComponents.tsx
+++ b/src/components/LazyComponents.tsx
@@ -14,7 +14,6 @@ import {
 // Lazy load all heavy components with content-specific loading states
 export const LazyHeroSection = dynamic(() => import('./HeroSection'), {
   loading: () => <HeroSectionSkeleton />,
-  ssr: false,
 });
 
 export const LazyWatchSection = dynamic(() => import('./WatchSection'), {

--- a/src/components/ParallaxElement.tsx
+++ b/src/components/ParallaxElement.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useParallax } from '@/lib/parallax-context';
+import { useParallax, type RellaxInstance } from '@/lib/parallax-context';
 import { Box } from '@mantine/core';
 import { useEffect, useRef } from 'react';
 
@@ -22,12 +22,7 @@ export default function ParallaxElement({
   style = {},
 }: ParallaxElementProps) {
   const elementRef = useRef<HTMLDivElement>(null);
-  const instanceRef =
-    useRef<
-      ReturnType<typeof useParallax>['createRellaxInstance'] extends (...args: any[]) => infer R
-        ? R
-        : never | null
-    >(null);
+  const instanceRef = useRef<RellaxInstance | null>(null);
   const { createRellaxInstance, destroyRellaxInstance, isReducedMotion, globalSpeedMultiplier } =
     useParallax();
 
@@ -43,18 +38,25 @@ export default function ParallaxElement({
     }
 
     // Wait a bit for the element to be fully rendered
-    const timer = setTimeout(() => {
-      const instance = createRellaxInstance(elementRef.current!, speed, {
+    let isCancelled = false;
+    const timer = setTimeout(async () => {
+      const instance = await createRellaxInstance(elementRef.current!, speed, {
         center,
         horizontal,
       });
 
-      if (instance) {
+      if (isCancelled && instance) {
+        destroyRellaxInstance(instance);
+        return;
+      }
+
+      if (!isCancelled && instance) {
         instanceRef.current = instance;
       }
     }, 200);
 
     return () => {
+      isCancelled = true;
       clearTimeout(timer);
       if (instanceRef.current) {
         destroyRellaxInstance(instanceRef.current);

--- a/src/components/ParallaxElement.tsx
+++ b/src/components/ParallaxElement.tsx
@@ -27,7 +27,9 @@ export default function ParallaxElement({
     useParallax();
 
   useEffect(() => {
-    if (!elementRef.current || isReducedMotion) {
+    const element = elementRef.current;
+
+    if (!element || isReducedMotion) {
       return;
     }
 
@@ -40,7 +42,11 @@ export default function ParallaxElement({
     // Wait a bit for the element to be fully rendered
     let isCancelled = false;
     const timer = setTimeout(async () => {
-      const instance = await createRellaxInstance(elementRef.current!, speed, {
+      if (isCancelled || !element.isConnected) {
+        return;
+      }
+
+      const instance = await createRellaxInstance(element, speed, {
         center,
         horizontal,
       });

--- a/src/components/ResumeYouTubeEmbed.tsx
+++ b/src/components/ResumeYouTubeEmbed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Box, type BoxProps } from '@mantine/core';
+import { Box, Stack, Text, type BoxProps } from '@mantine/core';
+import { IconPlayerPlay } from '@tabler/icons-react';
 import { memo, useEffect, useRef, useState } from 'react';
 
 const YOUTUBE_IFRAME_API_SRC = 'https://www.youtube.com/iframe_api';
@@ -11,7 +12,6 @@ const RESUME_AFTER_SECONDS = 10;
 const NEAR_END_SECONDS = 15;
 const SAVE_INTERVAL_MS = 4000;
 const YOUTUBE_API_TIMEOUT_MS = 8000;
-const PLAYER_LOAD_ROOT_MARGIN = '400px 0px';
 const YOUTUBE_REFERRER_POLICY = 'strict-origin-when-cross-origin';
 
 interface ResumeYouTubeEmbedProps extends Omit<BoxProps, 'children'> {
@@ -70,6 +70,9 @@ const getProgressKey = (youtubeId: string) => `${PROGRESS_KEY_PREFIX}:${youtubeI
 
 const getFallbackEmbedUrl = (youtubeId: string) =>
   `${YOUTUBE_EMBED_BASE_URL}/${youtubeId}?autoplay=0&rel=0&playsinline=1`;
+
+const getThumbnailUrl = (youtubeId: string) =>
+  `https://img.youtube.com/vi/${youtubeId}/maxresdefault.jpg`;
 
 const getStoredProgress = (youtubeId: string) => {
   try {
@@ -296,37 +299,6 @@ const ResumeYouTubeEmbed = memo(
       };
     }, [shouldLoadPlayer, title, youtubeId]);
 
-    useEffect(() => {
-      if (shouldLoadPlayer) {
-        return undefined;
-      }
-
-      const container = containerRef.current;
-
-      if (!container || !('IntersectionObserver' in window)) {
-        setShouldLoadPlayer(true);
-        return undefined;
-      }
-
-      const observer = new IntersectionObserver(
-        entries => {
-          const entry = entries[0];
-
-          if (entry?.isIntersecting) {
-            setShouldLoadPlayer(true);
-            observer.disconnect();
-          }
-        },
-        { rootMargin: PLAYER_LOAD_ROOT_MARGIN }
-      );
-
-      observer.observe(container);
-
-      return () => {
-        observer.disconnect();
-      };
-    }, [shouldLoadPlayer, youtubeId]);
-
     if (useFallbackEmbed) {
       return (
         <Box
@@ -350,6 +322,50 @@ const ResumeYouTubeEmbed = memo(
               border: 0,
             }}
           />
+        </Box>
+      );
+    }
+
+    if (!shouldLoadPlayer) {
+      return (
+        <Box
+          {...boxProps}
+          component="button"
+          type="button"
+          onClick={() => setShouldLoadPlayer(true)}
+          aria-label={`Play ${title}`}
+          style={{
+            width: '100%',
+            height: '100%',
+            border: 0,
+            cursor: 'pointer',
+            padding: 0,
+            color: '#FFFFFF',
+            background: `linear-gradient(rgba(14, 20, 27, 0.18), rgba(14, 20, 27, 0.42)), url(${getThumbnailUrl(
+              youtubeId
+            )}) center / cover`,
+            ...style,
+          }}
+        >
+          <Stack align="center" justify="center" gap="xs" h="100%">
+            <Box
+              aria-hidden="true"
+              style={{
+                alignItems: 'center',
+                background: 'rgba(14, 20, 27, 0.78)',
+                borderRadius: '999px',
+                display: 'inline-flex',
+                height: '64px',
+                justifyContent: 'center',
+                width: '64px',
+              }}
+            >
+              <IconPlayerPlay size={30} fill="currentColor" />
+            </Box>
+            <Text fw={700} size="sm" style={{ textShadow: '0 1px 8px rgba(0, 0, 0, 0.55)' }}>
+              Play video
+            </Text>
+          </Stack>
         </Box>
       );
     }

--- a/src/components/ResumeYouTubeEmbed.tsx
+++ b/src/components/ResumeYouTubeEmbed.tsx
@@ -71,8 +71,8 @@ const getProgressKey = (youtubeId: string) => `${PROGRESS_KEY_PREFIX}:${youtubeI
 const getFallbackEmbedUrl = (youtubeId: string) =>
   `${YOUTUBE_EMBED_BASE_URL}/${youtubeId}?autoplay=0&rel=0&playsinline=1`;
 
-const getThumbnailUrl = (youtubeId: string) =>
-  `https://img.youtube.com/vi/${youtubeId}/maxresdefault.jpg`;
+const getThumbnailUrl = (youtubeId: string, quality: 'hqdefault' | 'mqdefault' = 'hqdefault') =>
+  `https://img.youtube.com/vi/${youtubeId}/${quality}.jpg`;
 
 const getStoredProgress = (youtubeId: string) => {
   try {
@@ -200,6 +200,11 @@ const ResumeYouTubeEmbed = memo(
     const saveIntervalRef = useRef<number | null>(null);
     const [useFallbackEmbed, setUseFallbackEmbed] = useState(false);
     const [shouldLoadPlayer, setShouldLoadPlayer] = useState(false);
+    const [thumbnailSrc, setThumbnailSrc] = useState(() => getThumbnailUrl(youtubeId));
+
+    useEffect(() => {
+      setThumbnailSrc(getThumbnailUrl(youtubeId));
+    }, [youtubeId]);
 
     useEffect(() => {
       let isMounted = true;
@@ -335,22 +340,56 @@ const ResumeYouTubeEmbed = memo(
           onClick={() => setShouldLoadPlayer(true)}
           aria-label={`Play ${title}`}
           style={{
+            position: 'relative',
+            overflow: 'hidden',
             width: '100%',
             height: '100%',
             border: 0,
             cursor: 'pointer',
             padding: 0,
             color: '#FFFFFF',
-            background: `linear-gradient(rgba(14, 20, 27, 0.18), rgba(14, 20, 27, 0.42)), url(${getThumbnailUrl(
-              youtubeId
-            )}) center / cover`,
             ...style,
           }}
         >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            alt=""
+            aria-hidden="true"
+            src={thumbnailSrc}
+            loading="lazy"
+            decoding="async"
+            onError={event => {
+              const nextSrc = getThumbnailUrl(youtubeId, 'mqdefault');
+
+              if (event.currentTarget.src.endsWith('/mqdefault.jpg')) {
+                return;
+              }
+
+              setThumbnailSrc(nextSrc);
+            }}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              objectFit: 'cover',
+              pointerEvents: 'none',
+            }}
+          />
+          <Box
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              background: 'linear-gradient(rgba(14, 20, 27, 0.18), rgba(14, 20, 27, 0.42))',
+            }}
+          />
           <Stack align="center" justify="center" gap="xs" h="100%">
             <Box
               aria-hidden="true"
               style={{
+                position: 'relative',
+                zIndex: 1,
                 alignItems: 'center',
                 background: 'rgba(14, 20, 27, 0.78)',
                 borderRadius: '999px',
@@ -362,7 +401,15 @@ const ResumeYouTubeEmbed = memo(
             >
               <IconPlayerPlay size={30} fill="currentColor" />
             </Box>
-            <Text fw={700} size="sm" style={{ textShadow: '0 1px 8px rgba(0, 0, 0, 0.55)' }}>
+            <Text
+              fw={700}
+              size="sm"
+              style={{
+                position: 'relative',
+                zIndex: 1,
+                textShadow: '0 1px 8px rgba(0, 0, 0, 0.55)',
+              }}
+            >
               Play video
             </Text>
           </Stack>

--- a/src/components/WatchSection.tsx
+++ b/src/components/WatchSection.tsx
@@ -226,7 +226,7 @@ const WatchSection = memo(() => {
       <Stack gap="xl">
         <Box ta="center" mb="md">
           <Title
-            order={1}
+            order={2}
             size="h1"
             mb="md"
             style={{

--- a/src/components/WorkSection.tsx
+++ b/src/components/WorkSection.tsx
@@ -39,7 +39,7 @@ const WorkSection = memo(() => {
         {/* Header */}
         <Box ta="center" mb="xl">
           <Title
-            order={1}
+            order={2}
             size="h1"
             mb="md"
             style={{

--- a/src/components/unified-card/sections/ThumbnailSection.tsx
+++ b/src/components/unified-card/sections/ThumbnailSection.tsx
@@ -73,6 +73,7 @@ const ThumbnailSection = memo(
           <Image
             src={thumbnail.src}
             alt={thumbnail.alt}
+            loading="lazy"
             style={{
               width: '100%',
               height: '100%',

--- a/src/lib/parallax-context.tsx
+++ b/src/lib/parallax-context.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
-import Rellax from 'rellax';
+import type Rellax from 'rellax';
 
 // Type definitions for Rellax
-type RellaxInstance =
+export type RellaxInstance =
   | {
       destroy: () => void;
       refresh: () => void;
@@ -21,7 +21,7 @@ interface ParallaxContextType {
     element: HTMLElement,
     speed?: number,
     options?: { center?: boolean; horizontal?: boolean }
-  ) => RellaxInstance | null;
+  ) => Promise<RellaxInstance | null>;
   destroyRellaxInstance: (instance: RellaxInstance) => void;
   setGlobalSpeedMultiplier: (multiplier: number) => void;
 }
@@ -61,16 +61,17 @@ export const ParallaxProvider: React.FC<ParallaxProviderProps> = ({ children }) 
     };
   }, []);
 
-  const createRellaxInstance = (
+  const createRellaxInstance = async (
     element: HTMLElement,
     speed: number = -2,
     options: { center?: boolean; horizontal?: boolean } = {}
-  ): RellaxInstance | null => {
+  ): Promise<RellaxInstance | null> => {
     if (isReducedMotion || typeof window === 'undefined') {
       return null;
     }
 
     try {
+      const { default: Rellax } = await import('rellax');
       const adjustedSpeed = speed * globalSpeedMultiplier;
       const { center = false, horizontal = false } = options;
       const instance = new Rellax(element, {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -32,7 +32,7 @@ export const seoConfig = {
   ],
   author: 'BuiltByGervonte LLC',
   url: 'https://builtbygervonte.com',
-  image: 'https://builtbygervonte.com/og-image.png',
+  image: 'https://builtbygervonte.com/og-image',
   linkedinHandle: 'gervonte-fowler-5a7781158',
   githubHandle: 'gervonte',
 };


### PR DESCRIPTION
# Pull Request

## Title

[BBG-48] Improve homepage Lighthouse performance and SEO signals

## Summary

This PR improves real homepage Lighthouse outcomes by making critical content available earlier and reducing unnecessary early client work. The hero content is now rendered directly instead of being delayed behind a lazy client wrapper, and heavy interactive behavior is deferred or made more intentional. It also updates metadata image configuration to match the actual OG image route, adds smaller loading optimizations for non-critical media, and hardens the Vercel Preview Lighthouse workflow so CI verifies the protection-bypass header before auditing the deployed app.

## Linear

- [BBG-48](https://linear.app/gervonte/issue/BBG-48/improve-real-app-lighthouse-performance-and-seo-scores)
- Closes BBG-48

## Scope

- Included: homepage rendering/performance/SEO changes tied to BBG-48, including hero rendering path, parallax loading behavior, YouTube embed loading strategy, metadata image URL fix, and lazy-loading tweaks.
- Included: Vercel Preview Lighthouse preflight hardening so protected preview responses with the Vercel Authentication shell do not produce misleading preview scores, plus reporting updates so PR comments use LHCI's representative run.
- Not included: Lighthouse threshold changes, artifact upload path changes, deployment strategy changes, or unrelated feature/UI redesign work.

## Changes

- Switched homepage hero usage to direct hero component rendering for earlier meaningful content.
- Removed client-only SSR disable on hero lazy component path.
- Disabled local Inter font preload to reduce early page load pressure.
- Refactored parallax context/component setup to async-load Rellax and safely handle cancellation/cleanup.
- Reworked resume YouTube embed to click-to-load with thumbnail placeholder instead of eager intersection-triggered player startup.
- Updated SEO image URL from `/og-image.png` to `/og-image` to match the implemented route.
- Added lazy loading hints for non-critical images.
- Adjusted section heading order props across multiple sections for improved semantic structure.
- Added Vercel preview preflight checks for Vercel Authentication responses, verified Lighthouse bypass header configuration, and documented the Vercel Preview `noindex` caveat in preview report comments.
- Updated Lighthouse PR comments to report LHCI's representative run instead of the first JSON artifact.

## Testing

- [ ] pnpm dev (verified app starts with no errors)
- [ ] Verified UI in desktop
- [ ] Verified navigation + routes work as expected
- [ ] Verified data flows / ingestion (if applicable)
- [x] Other manual testing:
  - Ran with Node 22.14.0 and pnpm 11.2.2
  - `pnpm run check` passed (type-check, lint, format check)
  - `pnpm run build:ci` passed (Next production build completed successfully; homepage remains statically generated)
  - `actionlint .github/workflows/performance-monitor.yml` passed
  - Confirmed unauthenticated Vercel Preview returns the Vercel Authentication shell with `x-robots-tag: noindex`, explaining stale preview SEO/performance results when bypass is not active
  - Confirmed `lighthouserc.cjs` includes `x-vercel-protection-bypass` when `VERCEL_AUTOMATION_BYPASS_SECRET` is present
  - Inspected Lighthouse artifacts from runs `26420139036` and `26420154925` to confirm representative-run scores and remaining audit drivers

## Notes / Follow-ups

- Latest local production Lighthouse artifacts show representative Performance 73, Accessibility 93, Best Practices 96, SEO 100, LCP about 2.9s, max potential FID about 430ms, and CLS 0.018. The PR comment previously showed 53 because it read the first run artifact instead of LHCI's representative run.
- Latest Vercel Preview Lighthouse artifacts show representative Performance 80, Accessibility 93, Best Practices 100, SEO 66, LCP about 1.9s, max potential FID about 430ms, and CLS 0.018.
- Vercel Preview SEO remains 66 because Lighthouse fails `is-crawlable` on the `.vercel.app` preview URL due to preview `noindex`. Local production SEO is 100, so the remaining SEO issue is documented as a Vercel Preview platform header rather than app metadata.
- Remaining performance bottlenecks are mainly main-thread work and JavaScript bootup time from the client-heavy homepage stack; those are documented for follow-up unless this PR should continue into a larger frontend bundle reduction.