### PR TITLE
[BBG-49] Fix embeds and refresh content copy

### DIFF
--- a/scripts/check-watch-page.js
+++ b/scripts/check-watch-page.js
@@ -10,6 +10,7 @@ const files = {
   layout: 'src/app/layout.tsx',
   page: 'src/app/page.tsx',
   footer: 'src/components/Footer.tsx',
+  resumeYouTubeEmbed: 'src/components/ResumeYouTubeEmbed.tsx',
   watchSection: 'src/components/WatchSection.tsx',
   watchVideos: 'src/data/watch-videos.ts',
 };
@@ -185,6 +186,28 @@ check(
 check(
   includes(sources.watchSection, "video.status === 'coming-soon'"),
   `${pathLabel(files.watchSection)} must communicate coming-soon video state.`
+);
+check(
+  includes(sources.resumeYouTubeEmbed, 'enablejsapi: 1') &&
+    includes(sources.resumeYouTubeEmbed, "enablejsapi: '1'"),
+  `${pathLabel(files.resumeYouTubeEmbed)} must enable the YouTube IFrame API for embedded players.`
+);
+check(
+  includes(sources.resumeYouTubeEmbed, 'autoplay: 0') &&
+    includes(sources.resumeYouTubeEmbed, "autoplay: '0'"),
+  `${pathLabel(files.resumeYouTubeEmbed)} must not autoplay the native YouTube player.`
+);
+check(
+  includes(sources.resumeYouTubeEmbed, "const YOUTUBE_EMBED_HOST = 'https://www.youtube.com'") &&
+    includes(sources.resumeYouTubeEmbed, 'host: YOUTUBE_EMBED_HOST'),
+  `${pathLabel(files.resumeYouTubeEmbed)} must use the standard YouTube embed host for native player controls.`
+);
+check(
+  includes(sources.resumeYouTubeEmbed, 'const getCurrentOrigin') &&
+    includes(sources.resumeYouTubeEmbed, 'window.location.origin') &&
+    includes(sources.resumeYouTubeEmbed, 'origin: getCurrentOrigin()') &&
+    includes(sources.resumeYouTubeEmbed, "params.set('origin', origin)"),
+  `${pathLabel(files.resumeYouTubeEmbed)} must pass the current page origin to YouTube embeds.`
 );
 
 if (failures.length > 0) {

--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -95,6 +95,14 @@ const getCategoryDisplayName = (category: string) => {
   }
 };
 
+const getSkillCardTitle = (category: string) => {
+  if (category === 'ai-ml') {
+    return 'AI Engineering Workflow';
+  }
+
+  return `${getCategoryDisplayName(category)} Skills`;
+};
+
 // Utility function to get ELI5 description for category
 const getCategoryELI5Description = (category: string): string => {
   switch (category) {
@@ -109,7 +117,7 @@ const getCategoryELI5Description = (category: string): string => {
     case 'tools':
       return 'The digital toolbox that helps developers work smarter';
     case 'ai-ml':
-      return 'AI copilots and workflow tools that sharpen product and engineering work';
+      return 'AI copilots, coding agents, and workflow tools used across product planning, implementation, review, and documentation.';
     case 'soft':
       return 'The people skills that make technical work successful';
     default:
@@ -164,9 +172,14 @@ const getSkillIconComponent = (skillName: string) => {
     case 'sentry':
       return <IconShield size={16} />;
     case 'codex':
-      return <IconRobot size={16} />;
     case 'linear mcp':
+    case 'chatgpt':
       return <IconRobot size={16} />;
+    case 'github copilot':
+      return <IconBrandGithub size={16} />;
+    case 'llm evaluation':
+    case 'prompt engineering':
+      return <IconTarget size={16} />;
 
     // Default fallback
     default:
@@ -213,7 +226,7 @@ const AboutSection = memo(() => {
             {Object.entries(skillCategories).map(([category, categorySkills]) => (
               <UnifiedCard
                 key={category}
-                title={`${getCategoryDisplayName(category)} Skills`}
+                title={getSkillCardTitle(category)}
                 subtitle={getCategoryELI5Description(category)}
                 subtitleColor="dimmed"
                 headerIcon={getCategoryIconComponent(category as Skill['category'])}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -55,8 +55,9 @@ export default function Footer() {
                 About
               </Title>
               <Text size="sm" c="dimmed" lh={1.6}>
-                Professional portfolio showcasing AI-assisted and traditional development work with
-                a touch of mono no aware aesthetics.
+                Full-stack software engineer building fintech products, technical content, and
+                creative systems with a focus on clear UX, practical workflows, and thoughtful
+                execution.
               </Text>
               <Group gap="xs">
                 <IconMapPin size={16} style={{ color: commonColors.accentPrimary }} />
@@ -181,12 +182,12 @@ export default function Footer() {
               </Title>
               <Text size="sm" c="dimmed" lh={1.6}>
                 Built with Codex, Next.js, TypeScript, Mantine UI, and sakura.js for a modern,
-                responsive experience.
+                responsive experience shaped by mono no aware aesthetics.
               </Text>
               <Group gap="xs">
                 <IconHeart size={16} style={{ color: commonColors.accentPrimary }} />
                 <Text size="xs" c="dimmed">
-                  Made with passion and sakura petals
+                  Made with taste.
                 </Text>
               </Group>
             </Stack>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -62,8 +62,8 @@ const HeroSection = memo(() => {
                 role="text"
                 aria-label="Software, content, and systems built by a creative engineer born and raised in The Bahamas"
               >
-                Software, content, and systems built by a creative Bahamian engineer based in the
-                U.S.
+                Full-stack software engineer building fintech products, technical content, and 0 to
+                1 creative systems.
                 <br />
                 <span aria-hidden="true">🇧🇸</span>
               </Text>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -60,7 +60,8 @@ const HeroSection = memo(() => {
                   color: commonColors.textSecondary,
                 }}
                 role="text"
-                aria-label="Software, content, and systems built by a creative engineer born and raised in The Bahamas"
+                aria-label="Full-stack software engineer building fintech products, technical content, and 0 to
+                1 creative systems."
               >
                 Full-stack software engineer building fintech products, technical content, and 0 to
                 1 creative systems.

--- a/src/components/ResumeYouTubeEmbed.tsx
+++ b/src/components/ResumeYouTubeEmbed.tsx
@@ -5,8 +5,8 @@ import { IconPlayerPlay } from '@tabler/icons-react';
 import { memo, useEffect, useRef, useState } from 'react';
 
 const YOUTUBE_IFRAME_API_SRC = 'https://www.youtube.com/iframe_api';
-const YOUTUBE_PRIVACY_HOST = 'https://www.youtube-nocookie.com';
-const YOUTUBE_EMBED_BASE_URL = `${YOUTUBE_PRIVACY_HOST}/embed`;
+const YOUTUBE_EMBED_HOST = 'https://www.youtube.com';
+const YOUTUBE_EMBED_BASE_URL = `${YOUTUBE_EMBED_HOST}/embed`;
 const PROGRESS_KEY_PREFIX = 'bbg-video-progress';
 const RESUME_AFTER_SECONDS = 10;
 const NEAR_END_SECONDS = 15;
@@ -40,6 +40,7 @@ interface YouTubePlayerOptions {
   playerVars?: {
     autoplay?: 0;
     enablejsapi?: 1;
+    origin?: string;
     playsinline?: 1;
     rel?: 0;
   };
@@ -68,8 +69,32 @@ let youtubeApiPromise: Promise<YouTubeApi> | undefined;
 
 const getProgressKey = (youtubeId: string) => `${PROGRESS_KEY_PREFIX}:${youtubeId}`;
 
+const getCurrentOrigin = () => {
+  if (typeof window === 'undefined') {
+    return undefined;
+  }
+
+  return window.location.origin;
+};
+
+const getEmbedSearchParams = () => {
+  const params = new URLSearchParams({
+    autoplay: '0',
+    enablejsapi: '1',
+    playsinline: '1',
+    rel: '0',
+  });
+  const origin = getCurrentOrigin();
+
+  if (origin) {
+    params.set('origin', origin);
+  }
+
+  return params;
+};
+
 const getFallbackEmbedUrl = (youtubeId: string) =>
-  `${YOUTUBE_EMBED_BASE_URL}/${youtubeId}?autoplay=0&rel=0&playsinline=1`;
+  `${YOUTUBE_EMBED_BASE_URL}/${youtubeId}?${getEmbedSearchParams().toString()}`;
 
 const getThumbnailUrl = (youtubeId: string, quality: 'hqdefault' | 'mqdefault' = 'hqdefault') =>
   `https://img.youtube.com/vi/${youtubeId}/${quality}.jpg`;
@@ -239,12 +264,13 @@ const ResumeYouTubeEmbed = memo(
 
           playerRef.current = new YT.Player(containerRef.current, {
             height: '100%',
-            host: YOUTUBE_PRIVACY_HOST,
+            host: YOUTUBE_EMBED_HOST,
             videoId: youtubeId,
             width: '100%',
             playerVars: {
               autoplay: 0,
               enablejsapi: 1,
+              origin: getCurrentOrigin(),
               playsinline: 1,
               rel: 0,
             },

--- a/src/data/manual-additions.json
+++ b/src/data/manual-additions.json
@@ -3,7 +3,7 @@
   "_note": "This file contains manually added data that supplements the auto-generated about-metadata.json. Add new skills, projects, or other data here.",
   "personalInfo": {
     "email": "hello@builtbygervonte.com",
-    "summary": "Full-stack software engineer with fintech experience, an M.S. in Computer Science, and hands-on work across React, Node.js, AI/ML research, and production-ready systems."
+    "summary": "Full-stack software engineer with venture-backed fintech experience, an M.S. in Computer Science, and hands-on work across React, Node.js, APIs, AI/ML research, and production-ready systems."
   },
   "leadership": [
     {
@@ -246,6 +246,26 @@
     {
       "name": "Linear MCP",
       "level": "intermediate",
+      "category": "ai-ml"
+    },
+    {
+      "name": "GitHub Copilot",
+      "level": "advanced",
+      "category": "ai-ml"
+    },
+    {
+      "name": "ChatGPT",
+      "level": "advanced",
+      "category": "ai-ml"
+    },
+    {
+      "name": "LLM Evaluation",
+      "level": "intermediate",
+      "category": "ai-ml"
+    },
+    {
+      "name": "Prompt Engineering",
+      "level": "advanced",
       "category": "ai-ml"
     }
   ]

--- a/src/data/watch-videos.ts
+++ b/src/data/watch-videos.ts
@@ -42,8 +42,8 @@ export const watchVideos: WatchVideo[] = [
   {
     id: 'ten-years-of-april',
     slug: 'ten-years-of-april',
-    title: 'How I Turned Scholarships & a Student Visa Into $250K by 24',
-    subtitle: '10+ Years of April',
+    title: 'How I Turned Scholarships & A Student Visa Into $250K by 24',
+    subtitle: 'A Lighthouse for a Nontraditional Path',
     description:
       'A long-form reflection on becoming a software engineer from The Bahamas, covering scholarships, student visa life, access to work, fintech, career disruption, immigration, forming an LLC, and building Rainy Day. The story behind BuiltByGervonte.',
     category: 'founder-story',
@@ -88,7 +88,7 @@ export const watchVideos: WatchVideo[] = [
     title: 'LEETCODE BEASTMODE - BEHIND THE SONG',
     subtitle: 'The DAW, the Mix, and the LeetCode Era',
     description:
-      'Behind the scenes of “LEETCODE BEASTMODE.” I break down the DAW setup, vocal chain, mixing choices, and the early 2023 to summer 2024 era in The Bahamas, when I was sharpening system design and LeetCode-styled questions before returning to the U.S. for my master’s degree.',
+      'Behind the scenes of “LEETCODE BEASTMODE.” I break down the DAW setup, vocal chain, mixing choices, and the early 2023 to summer 2024 era in The Bahamas, when I was sharpening my skillset across system design and LeetCode style questions while searching locally for software roles before ultimately returning to the U.S. for my master’s degree and access to a larger job market.',
     category: 'creative-breakdown',
     collection: 'Creative / Culture',
     youtubeUrl: 'https://www.youtube.com/watch?v=GlbWLTu42Ws',

--- a/src/lib/badge-contexts.ts
+++ b/src/lib/badge-contexts.ts
@@ -425,6 +425,48 @@ export const technologyContexts: Record<string, BadgeContext> = {
     ],
     capabilitiesLabel: 'What It Does:',
   },
+  'GitHub Copilot': {
+    title: 'GitHub Copilot',
+    description: 'AI pair programmer used for implementation, review, and editor-native assistance',
+    capabilities: [
+      'Accelerating implementation inside the editor',
+      'Reviewing code changes and suggesting improvements',
+      'Helping with repetitive development tasks',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  ChatGPT: {
+    title: 'ChatGPT',
+    description:
+      'General-purpose AI assistant for planning, research, debugging, and documentation',
+    capabilities: [
+      'Exploring product and technical decisions',
+      'Drafting documentation and implementation notes',
+      'Researching unfamiliar APIs and approaches',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  'LLM Evaluation': {
+    title: 'LLM Evaluation',
+    description: 'Practical evaluation of AI outputs for correctness, usefulness, and reliability',
+    capabilities: [
+      'Comparing AI outputs against expected behavior',
+      'Identifying failure modes and quality gaps',
+      'Refining prompts and workflows from evaluation results',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  'Prompt Engineering': {
+    title: 'Prompt Engineering',
+    description:
+      'Structuring instructions and context so AI tools produce usable engineering output',
+    capabilities: [
+      'Writing clear task instructions and acceptance criteria',
+      'Providing repository and product context to AI tools',
+      'Iterating prompts for implementation, review, and documentation',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
   Vite: {
     title: 'Vite',
     description: 'Fast build tool and development server',


### PR DESCRIPTION
## Summary

Fixes the featured Content section YouTube embed so native player controls behave correctly while preserving the existing resumable playback wrapper. This PR also refreshes homepage, footer, resume summary, and Watch copy so the site better reflects the current positioning, and expands the AI skills card into a broader AI-assisted engineering workflow card.

## Linear

- [BBG-49](https://linear.app/gervonte/issue/BBG-49/fix-embedded-youtube-player)

## Scope

- Updates the featured YouTube embed wrapper and source-level watch page checks.
- Refreshes focused portfolio copy in the hero, footer, resume summary, and Watch video metadata.
- Updates the Qualifications / Technical Skills AI card content, title, subtitle, skill list, icons, and tooltip context.
- Intentionally does not change deployment strategy, routing structure, data ingestion, or unrelated app behavior.

## Changes

- Use `https://www.youtube.com` for the interactive embed host instead of the privacy-enhanced host.
- Pass the current page `origin` when `enablejsapi` is enabled.
- Build fallback embed params with `URLSearchParams` while keeping `autoplay=0`.
- Add regression checks for the YouTube host, origin, IFrame API config, and autoplay behavior.
- Update hero, footer, resume summary, and Watch video copy to match the current portfolio narrative.
- Rename the AI skills card to `AI Engineering Workflow` and update its subtitle.
- Add GitHub Copilot, ChatGPT, LLM Evaluation, and Prompt Engineering alongside Codex and Linear MCP with requested proficiency levels.
- Add AI workflow icon and tooltip context for the new skills.

## Testing

- [ ] pnpm dev (verified app starts with no errors)
- [x] Verified UI in desktop
- [ ] Verified navigation + routes work as expected
- [ ] Verified data flows / ingestion (if applicable)
- [x] Other manual testing: verified the embedded YouTube control opens the video on YouTube and the embedded-player chapter hover preview appears where YouTube provides it
- [x] `pnpm run check`
- [x] `pnpm run build:ci`

## Notes / Follow-ups

- YouTube embeds show the embedded-player chapter preview UI; the full watch-page precise seeking UI is controlled by YouTube and is not exposed as a documented iframe parameter.
