### PR TITLE
[Hotfix] Tooltip hidden behind technical details modal

### DIFF
--- a/src/components/BadgeWithTooltip.tsx
+++ b/src/components/BadgeWithTooltip.tsx
@@ -65,7 +65,6 @@ const BadgeWithTooltip = memo(
         withArrow
         position="top"
         offset={8}
-        zIndex={1000}
       >
         <Badge
           {...badgeProps}

--- a/src/components/MobileTooltip.tsx
+++ b/src/components/MobileTooltip.tsx
@@ -10,13 +10,17 @@ export function TooltipZIndexProvider({ value, children }: { value: number; chil
   return <TooltipZIndexContext.Provider value={value}>{children}</TooltipZIndexContext.Provider>;
 }
 
-interface MobileTooltipProps extends Omit<TooltipProps, 'opened' | 'onOpen' | 'onClose'> {
+interface MobileTooltipProps extends Omit<
+  TooltipProps,
+  'opened' | 'onOpen' | 'onClose' | 'zIndex'
+> {
   children: ReactNode;
   label: string | ReactNode;
   delay?: number;
   disabled?: boolean;
   trigger?: 'hover' | 'click' | 'both';
   mobileBehavior?: 'tap' | 'hold' | 'both';
+  zIndex?: number;
 }
 
 /**

--- a/src/components/MobileTooltip.tsx
+++ b/src/components/MobileTooltip.tsx
@@ -2,7 +2,13 @@
 
 import { useMobileTooltip } from '@/hooks/useMobileTooltip';
 import { Tooltip, TooltipProps } from '@mantine/core';
-import { ReactNode } from 'react';
+import { createContext, ReactNode, useContext } from 'react';
+
+const TooltipZIndexContext = createContext<number | undefined>(undefined);
+
+export function TooltipZIndexProvider({ value, children }: { value: number; children: ReactNode }) {
+  return <TooltipZIndexContext.Provider value={value}>{children}</TooltipZIndexContext.Provider>;
+}
 
 interface MobileTooltipProps extends Omit<TooltipProps, 'opened' | 'onOpen' | 'onClose'> {
   children: ReactNode;
@@ -28,8 +34,12 @@ export function MobileTooltip({
   withArrow = true,
   position = 'top',
   offset = 8,
+  zIndex,
   ...props
 }: MobileTooltipProps) {
+  const contextZIndex = useContext(TooltipZIndexContext);
+  const resolvedZIndex = zIndex ?? contextZIndex ?? 1000;
+
   const { opened, handlers, ref } = useMobileTooltip({
     delay,
     disabled,
@@ -46,6 +56,7 @@ export function MobileTooltip({
     withArrow,
     position,
     offset,
+    zIndex: resolvedZIndex,
     // Mobile-specific styling
     styles: {
       tooltip: {
@@ -54,10 +65,10 @@ export function MobileTooltip({
         padding: '8px 12px',
         borderRadius: '8px',
         boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
-        zIndex: 1000,
+        zIndex: resolvedZIndex,
       },
       arrow: {
-        zIndex: 1001,
+        zIndex: resolvedZIndex + 1,
       },
     },
     // Prevent tooltip from being cut off on mobile

--- a/src/components/ThemeIconWithTooltip.tsx
+++ b/src/components/ThemeIconWithTooltip.tsx
@@ -65,7 +65,6 @@ const ThemeIconWithTooltip = memo(
         withArrow
         position="top"
         offset={8}
-        zIndex={1000}
       >
         <ThemeIcon
           {...themeIconProps}

--- a/src/components/technical-details/TechnicalDetailsModal.tsx
+++ b/src/components/technical-details/TechnicalDetailsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCommonColors } from '@/lib/theme-aware-colors';
+import { TooltipZIndexProvider } from '@/components/MobileTooltip';
 import '@/styles/technical-modal.css';
 import { Alert, Box, Button, Group, Modal, Text } from '@mantine/core';
 import { IconAlertCircle, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
@@ -291,69 +292,79 @@ const TechnicalDetailsModal = memo(({ project, opened, onClose }: TechnicalDetai
           </div>
         }
       >
-        <div>
-          {technicalSections.map(({ key, section }) => (
-            <div key={key} style={{ display: activeTab === key ? 'block' : 'none' }}>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
-                {/* Overview Card */}
-                <OverviewCard section={section} sectionKey={key} commonColors={commonColors} />
+        <TooltipZIndexProvider value={MODAL_CONFIG.tooltipZIndex}>
+          <div>
+            {technicalSections.map(({ key, section }) => (
+              <div key={key} style={{ display: activeTab === key ? 'block' : 'none' }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+                  {/* Overview Card */}
+                  <OverviewCard section={section} sectionKey={key} commonColors={commonColors} />
 
-                {/* Metrics Display */}
-                {shouldShowSection(section, 'metrics') ? (
-                  <MetricsCard section={section} sectionKey={key} commonColors={commonColors} />
-                ) : null}
+                  {/* Metrics Display */}
+                  {shouldShowSection(section, 'metrics') ? (
+                    <MetricsCard section={section} sectionKey={key} commonColors={commonColors} />
+                  ) : null}
 
-                {/* Tools & Technologies */}
-                {shouldShowSection(section, 'tools') ? (
-                  <ToolsCard section={section} sectionKey={key} commonColors={commonColors} />
-                ) : null}
+                  {/* Tools & Technologies */}
+                  {shouldShowSection(section, 'tools') ? (
+                    <ToolsCard section={section} sectionKey={key} commonColors={commonColors} />
+                  ) : null}
 
-                {/* Monitoring Data */}
-                {shouldShowSection(section, 'monitoring') ? (
-                  <MonitoringCard section={section} sectionKey={key} commonColors={commonColors} />
-                ) : null}
+                  {/* Monitoring Data */}
+                  {shouldShowSection(section, 'monitoring') ? (
+                    <MonitoringCard
+                      section={section}
+                      sectionKey={key}
+                      commonColors={commonColors}
+                    />
+                  ) : null}
 
-                {/* Workflows */}
-                {shouldShowSection(section, 'workflows') ? (
-                  <WorkflowsCard section={section} sectionKey={key} commonColors={commonColors} />
-                ) : null}
+                  {/* Workflows */}
+                  {shouldShowSection(section, 'workflows') ? (
+                    <WorkflowsCard section={section} sectionKey={key} commonColors={commonColors} />
+                  ) : null}
 
-                {/* Performance Metrics */}
-                <PerformanceCard section={section} sectionKey={key} commonColors={commonColors} />
+                  {/* Performance Metrics */}
+                  <PerformanceCard section={section} sectionKey={key} commonColors={commonColors} />
 
-                {/* Architecture Data */}
-                {shouldShowSection(section, 'architecture') ? (
-                  <ArchitectureCard
-                    section={section}
-                    sectionKey={key}
-                    commonColors={commonColors}
-                  />
-                ) : null}
+                  {/* Architecture Data */}
+                  {shouldShowSection(section, 'architecture') ? (
+                    <ArchitectureCard
+                      section={section}
+                      sectionKey={key}
+                      commonColors={commonColors}
+                    />
+                  ) : null}
 
-                {/* Deployment Data for CI/CD */}
-                {key === 'cicd' && shouldShowSection(section, 'deployment') ? (
-                  <DeploymentCard section={section} sectionKey={key} commonColors={commonColors} />
-                ) : null}
+                  {/* Deployment Data for CI/CD */}
+                  {key === 'cicd' && shouldShowSection(section, 'deployment') ? (
+                    <DeploymentCard
+                      section={section}
+                      sectionKey={key}
+                      commonColors={commonColors}
+                    />
+                  ) : null}
 
-                {/* Screenshots Section */}
-                {shouldShowSection(section, 'screenshots') ? (
-                  <ScreenshotGallery
-                    screenshots={section.screenshots}
-                    sectionKey={key}
-                    commonColors={commonColors}
-                    onImageSelect={image => {
-                      setSelectedImage(image);
-                      const index = currentTabScreenshots.findIndex(img => img.src === image.src);
-                      if (index !== -1) {
-                        setCurrentImageIndex(index);
-                      }
-                    }}
-                  />
-                ) : null}
+                  {/* Screenshots Section */}
+                  {shouldShowSection(section, 'screenshots') ? (
+                    <ScreenshotGallery
+                      screenshots={section.screenshots}
+                      sectionKey={key}
+                      commonColors={commonColors}
+                      onImageSelect={image => {
+                        setSelectedImage(image);
+                        const index = currentTabScreenshots.findIndex(img => img.src === image.src);
+                        if (index !== -1) {
+                          setCurrentImageIndex(index);
+                        }
+                      }}
+                    />
+                  ) : null}
+                </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        </TooltipZIndexProvider>
       </Modal>
 
       {/* Image Modal */}

--- a/src/components/technical-details/types.ts
+++ b/src/components/technical-details/types.ts
@@ -85,5 +85,7 @@ export const MODAL_CONFIG = {
   imageMaxHeight: '86vh',
   /** Above site header (Header.tsx uses 1100) */
   detailsZIndex: 1150,
+  /** Above details modal, below lightbox */
+  tooltipZIndex: 1160,
   lightboxZIndex: 1200,
 } as const;

--- a/src/lib/badge-contexts.ts
+++ b/src/lib/badge-contexts.ts
@@ -273,6 +273,48 @@ export const technologyContexts: Record<string, BadgeContext> = {
     ],
     capabilitiesLabel: 'What It Does:',
   },
+  'Row Level Security': {
+    title: 'Row Level Security',
+    description: 'Postgres security policy layer for enforcing user-scoped data access',
+    capabilities: [
+      'Restricting database rows by authenticated user',
+      'Protecting account, statement, and transaction records at the database layer',
+      'Reducing reliance on application-only access checks',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  'Data Normalization': {
+    title: 'Data Normalization',
+    description:
+      'Process for converting inconsistent source data into a consistent application model',
+    capabilities: [
+      'Mapping bank-specific statement formats into shared transaction records',
+      'Standardizing dates, descriptions, amounts, accounts, and categories',
+      'Creating reliable downstream inputs for summaries, review flows, and forecasts',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  'PDF Ingestion': {
+    title: 'PDF Ingestion',
+    description: 'Import workflow for extracting transaction data from uploaded PDF statements',
+    capabilities: [
+      'Parsing PDF bank statements into structured transaction data',
+      'Handling institution-specific statement layouts and edge cases',
+      'Supporting uploaded-statement workflows where direct API coverage is limited',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  'Integration Testing': {
+    title: 'Integration Testing',
+    description:
+      'Testing approach for validating that connected product workflows behave correctly together',
+    capabilities: [
+      'Checking parser, persistence, and review flows across realistic inputs',
+      'Catching regressions in CSV and PDF ingestion behavior',
+      'Validating edge cases such as malformed rows, date parsing, and duplicate detection',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
   MongoDB: {
     title: 'MongoDB',
     description: 'NoSQL document database for modern applications',


### PR DESCRIPTION
## Summary

Tooltips inside the Technical Details modal were rendering behind the modal overlay because the modal z-index was raised to `1150` while tooltips stayed at `1000`. This PR adds a scoped tooltip z-index layer (`1160`) via `TooltipZIndexProvider` so help icons and badge tooltips display correctly above the modal. It also adds badge context entries for Rainy Day-related technologies so tooltips show meaningful copy instead of falling back to defaults.

## Linear

No Linear issue — ad hoc bug fix.

## Scope

**Included:**
- Tooltip z-index fix for the Technical Details modal
- Badge context updates for new technology labels

**Not included:**
- Changes to modal layout, deployment, or other tooltip behavior site-wide (defaults remain `1000` outside the modal)
- Lightbox modal z-index changes

## Changes

- Added `tooltipZIndex: 1160` to `MODAL_CONFIG` (above details modal `1150`, below lightbox `1200`)
- Added `TooltipZIndexProvider` and updated `MobileTooltip` to resolve z-index from prop, context, or default
- Wrapped Technical Details modal body content with `TooltipZIndexProvider`
- Removed hardcoded `zIndex={1000}` from `BadgeWithTooltip` and `ThemeIconWithTooltip` so modal context applies
- Added badge contexts for **Row Level Security**, **Data Normalization**, **PDF Ingestion**, and **Integration Testing**

## Testing

- [x] `pnpm dev` (verified app starts with no errors)
- [x] Verified UI in desktop — tooltips appear above Technical Details modal on hover/tap
- [ ] Verified navigation + routes work as expected
- [ ] Verified data flows / ingestion (if applicable)
- [x] Other manual testing: hovered “?” help icons and badge tooltips inside Technical Details modal; confirmed tooltips are no longer hidden behind modal content

## Notes / Follow-ups

- Tooltip z-index is scoped to the Technical Details modal only; site-wide tooltips still default to `1000`
