### PR TITLE
[BBG-96] Align portfolio around Rainy Day flow

### DIFF
--- a/THEME_SWITCHING.md
+++ b/THEME_SWITCHING.md
@@ -7,7 +7,7 @@ The portfolio now has two separate theme controls:
 - **Palette**: `Sakura` or `Ocean`
 - **Appearance Mode**: `Auto`, `Light`, or `Dark`
 
-`Auto` follows the user's system theme preference. Palette and appearance mode are stored separately in `localStorage`, so both settings persist across refreshes.
+Fresh visits default to the `Ocean` palette for the Rainy Day-led portfolio flow. The Rainy Day default includes a one-time localStorage migration so browsers that previously stored the old Sakura default also move to Ocean. `Auto` follows the user's system theme preference. Palette and appearance mode are stored separately in `localStorage`, so both settings persist across refreshes after that migration.
 
 ## How It Works
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,8 @@ const HomePage = memo(() => {
             aria-label="Professional experience"
             style={{
               minHeight: '100vh',
-              padding: '4rem 0',
+              padding: '8rem 0 4rem',
+              scrollMarginTop: '7rem',
             }}
           >
             <LazyExperienceSection />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,13 +9,14 @@ import {
 import { useTheme } from '@/lib/theme-context';
 import { Anchor, Box, Burger, Container, Group, Paper, Stack, Transition } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
+import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import ProfileAvatar from './ProfileAvatar';
 import ThemeModeSelector from './ThemeModeSelector';
 import ThemeToggle from './ThemeToggle';
 
 const HEADER_HEIGHT = 60;
 const HEADER_Z_INDEX = 1100;
+const BRAND_MARK_SIZE = 45;
 
 interface HeaderProps {
   links: Array<{ link: string; label: string }>;
@@ -100,7 +101,14 @@ export default function Header({ links }: HeaderProps) {
             style={{
               textDecoration: 'none',
               display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: BRAND_MARK_SIZE,
+              height: BRAND_MARK_SIZE,
               borderRadius: '999px',
+              background: commonColors.backgroundCard,
+              boxShadow: `0 2px 10px ${commonColors.shadowPrimaryLight}`,
+              border: `1px solid ${withOpacity(primaryColors[1] || '#FFCDD2', 0.28)}`,
             }}
             onClick={e => {
               e.preventDefault();
@@ -108,7 +116,18 @@ export default function Header({ links }: HeaderProps) {
               close();
             }}
           >
-            <ProfileAvatar />
+            <Image
+              src="/favicon.svg"
+              alt="BuiltByGervonte GF mark"
+              width={32}
+              height={32}
+              priority
+              style={{
+                display: 'block',
+                width: 32,
+                height: 32,
+              }}
+            />
           </Anchor>
 
           {/* Desktop Navigation */}

--- a/src/components/WatchSection.tsx
+++ b/src/components/WatchSection.tsx
@@ -240,7 +240,7 @@ const WatchSection = memo(() => {
             Content
           </Title>
           <Text size="xl" c={commonColors.textSecondary} maw={800} mx="auto">
-            Founder stories, product demos, music breakdowns, and build notes from the studio.
+            Rainy Day demos, product build notes, and creative breakdowns from the studio.
           </Text>
         </Box>
 
@@ -250,7 +250,7 @@ const WatchSection = memo(() => {
               <Stack gap="md" justify="center">
                 <Group gap="xs">
                   <Badge color="sakura" variant="filled" radius="sm">
-                    Featured Film
+                    Featured Demo
                   </Badge>
                   {featuredVideo.duration && (
                     <Badge

--- a/src/data/watch-videos.ts
+++ b/src/data/watch-videos.ts
@@ -29,6 +29,8 @@ export interface WatchVideo {
   publishedAt?: string;
   status: WatchVideoStatus;
   featured?: boolean;
+  // Preserve videos for future pages while excluding them from the homepage Content grid.
+  showInMainContent?: boolean;
   relatedLinks?: WatchVideoLink[];
 }
 
@@ -52,6 +54,7 @@ export const watchVideos: WatchVideo[] = [
     youtubeId: 'AbYNHzYtm_s',
     duration: '1:13:01',
     status: 'published',
+    showInMainContent: false,
   },
   {
     id: 'rainy-day-v0-1-0',
@@ -126,12 +129,16 @@ export const getWatchVideoBySlug = (slug: string): WatchVideo | undefined => {
 };
 
 export const getWatchVideosByCollection = (collection: WatchVideoCollection): WatchVideo[] => {
-  return watchVideos.filter(video => video.collection === collection);
+  return watchVideos.filter(
+    video => video.collection === collection && video.showInMainContent !== false
+  );
 };
 
 export const getWatchCollectionsWithVideos = (): WatchCollectionGroup[] => {
-  return watchCollections.map(collection => ({
-    collection,
-    videos: getWatchVideosByCollection(collection),
-  }));
+  return watchCollections
+    .map(collection => ({
+      collection,
+      videos: getWatchVideosByCollection(collection),
+    }))
+    .filter(group => group.videos.length > 0);
 };

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -18,6 +18,8 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 const THEME_STORAGE_KEY = 'portfolio-theme';
 const THEME_MODE_STORAGE_KEY = 'portfolio-theme-mode';
+const THEME_DEFAULT_VERSION_STORAGE_KEY = 'portfolio-theme-default-version';
+const CURRENT_THEME_DEFAULT_VERSION = 'rainy-day-ocean-v1';
 
 function getSystemColorScheme(): ResolvedColorScheme {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
@@ -29,6 +31,13 @@ function getSystemColorScheme(): ResolvedColorScheme {
 
 function getStoredTheme(): ThemeName {
   if (typeof window === 'undefined') {
+    return defaultTheme;
+  }
+
+  const storedDefaultVersion = localStorage.getItem(THEME_DEFAULT_VERSION_STORAGE_KEY);
+  if (storedDefaultVersion !== CURRENT_THEME_DEFAULT_VERSION) {
+    localStorage.setItem(THEME_DEFAULT_VERSION_STORAGE_KEY, CURRENT_THEME_DEFAULT_VERSION);
+    localStorage.setItem(THEME_STORAGE_KEY, defaultTheme);
     return defaultTheme;
   }
 

--- a/src/lib/theme-context.tsx
+++ b/src/lib/theme-context.tsx
@@ -21,6 +21,22 @@ const THEME_MODE_STORAGE_KEY = 'portfolio-theme-mode';
 const THEME_DEFAULT_VERSION_STORAGE_KEY = 'portfolio-theme-default-version';
 const CURRENT_THEME_DEFAULT_VERSION = 'rainy-day-ocean-v1';
 
+function getLocalStorageItem(key: string): string | null {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function setLocalStorageItem(key: string, value: string) {
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // Storage may be blocked or unavailable; keep the in-memory theme state.
+  }
+}
+
 function getSystemColorScheme(): ResolvedColorScheme {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
     return 'light';
@@ -34,14 +50,14 @@ function getStoredTheme(): ThemeName {
     return defaultTheme;
   }
 
-  const storedDefaultVersion = localStorage.getItem(THEME_DEFAULT_VERSION_STORAGE_KEY);
+  const storedDefaultVersion = getLocalStorageItem(THEME_DEFAULT_VERSION_STORAGE_KEY);
   if (storedDefaultVersion !== CURRENT_THEME_DEFAULT_VERSION) {
-    localStorage.setItem(THEME_DEFAULT_VERSION_STORAGE_KEY, CURRENT_THEME_DEFAULT_VERSION);
-    localStorage.setItem(THEME_STORAGE_KEY, defaultTheme);
+    setLocalStorageItem(THEME_DEFAULT_VERSION_STORAGE_KEY, CURRENT_THEME_DEFAULT_VERSION);
+    setLocalStorageItem(THEME_STORAGE_KEY, defaultTheme);
     return defaultTheme;
   }
 
-  const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+  const storedTheme = getLocalStorageItem(THEME_STORAGE_KEY);
   return storedTheme === 'sakura' || storedTheme === 'ocean' ? storedTheme : defaultTheme;
 }
 
@@ -50,7 +66,7 @@ function getStoredThemeMode(): ThemeMode {
     return 'auto';
   }
 
-  const storedThemeMode = localStorage.getItem(THEME_MODE_STORAGE_KEY);
+  const storedThemeMode = getLocalStorageItem(THEME_MODE_STORAGE_KEY);
   return storedThemeMode === 'light' || storedThemeMode === 'dark' || storedThemeMode === 'auto'
     ? storedThemeMode
     : 'auto';
@@ -77,7 +93,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    localStorage.setItem(THEME_STORAGE_KEY, currentTheme);
+    setLocalStorageItem(THEME_STORAGE_KEY, currentTheme);
   }, [currentTheme, isHydrated]);
 
   useEffect(() => {
@@ -85,7 +101,7 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    localStorage.setItem(THEME_MODE_STORAGE_KEY, themeMode);
+    setLocalStorageItem(THEME_MODE_STORAGE_KEY, themeMode);
   }, [themeMode, isHydrated]);
 
   useEffect(() => {

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -230,4 +230,4 @@ export const themes = {
 export const getTheme = (themeName: ThemeName, colorScheme: ResolvedColorScheme = 'light') =>
   themes[themeName][colorScheme];
 
-export const defaultTheme: ThemeName = 'sakura';
+export const defaultTheme: ThemeName = 'ocean';


### PR DESCRIPTION
## Summary

Updates the BuiltByGervonte portfolio so the default experience is Rainy Day-led and uses the Ocean palette. The Content section now emphasizes Rainy Day demos, hides the founder story from the main homepage grid without deleting the asset, and preserves section-level parallax with spacing fixes for Professional Experience.

## Linear

- [BBG-96](https://linear.app/gervonte/issue/BBG-96/improvement-align-builtbygervonte-portfolio-around-rainy-day-brand)

## Scope

- Aligns homepage theme, Content flow, nav mark, and section spacing with BBG-96.
- Preserves the founder story data for future use outside the main Content grid.
- Does not redesign Rainy Day product pages or change deployment strategy.

## Changes

- Defaulted fresh visits to the Ocean/Rainy Day palette.
- Added a one-time localStorage migration so browsers with the old Sakura default move to Ocean.
- Hid the founder story from homepage Content collections while preserving its video metadata.
- Updated Content copy and featured badge to lead with Rainy Day v0.2.0.
- Added extra clearance for the Professional Experience section while keeping section-level parallax.
- Replaced the nav portrait avatar with the existing GF favicon mark.
- Documented the Ocean default behavior in `THEME_SWITCHING.md`.

## Testing

- [ ] pnpm dev (verified app starts with no errors)
- [ ] Verified UI in desktop
- [ ] Verified navigation + routes work as expected
- [ ] Verified data flows / ingestion (if applicable)
- [x] Other manual testing:
  - `pnpm run check`
  - `pnpm run build:ci`
  - `git diff --check`

## Notes / Follow-ups

- Browser/dev-server verification was limited by sandbox approval and local dependency restore constraints during the session.