### PR TITLE
[BBG-98] Refresh Rainy Day portfolio content

### DIFF
--- a/src/data/manual-additions.json
+++ b/src/data/manual-additions.json
@@ -47,7 +47,7 @@
       "achievements": [
         "Founded Rainy Day, a statement-first personal finance platform for Caribbean consumers with limited connected-account coverage, using bank statements as the primary financial data source.",
         "Expanded Rainy Day ingestion across 4 institutions including CIBC Caribbean, Scotiabank Caribbean, Bank of The Bahamas, and Teachers & Salaried Workers Co-operative Credit Union, normalizing CSV/PDF statements into a canonical transaction model.",
-        "Used PostHog funnel analytics to diagnose a profile-selection gate causing 77% drop-off before product entry; redesigned onboarding to raise first-time entry from 23% to 97% and full-product reach from 0% to 27% across 100+ demo users.",
+        "Used PostHog funnel analytics to diagnose a profile-selection gate causing 44% drop-off before product entry; redesigned onboarding to raise first-time entry to 97% and full-product reach from 0% to 30% across 60+ real demo users.",
         "Designed deterministic analysis workflows for recurring bills, income signals, 10 automatic default categories, and projected cash flow with user-facing explanations.",
         "Architected Supabase/Postgres persistence with Row Level Security, transactional upload RPCs, statement hashing, parser validation, and overlap-safe deduplication."
       ]

--- a/src/data/projects-metadata.json
+++ b/src/data/projects-metadata.json
@@ -241,7 +241,7 @@
               "icon": "file-upload",
               "eyebrow": "Ingestion & Normalization",
               "title": "4 Caribbean institutions. Cash included. One consistent financial picture.",
-              "description": "CSV and PDF statements from four Caribbean banks and credit unions are normalized alongside manually tracked cash transactions. Support for additional institutions is prioritized and expanded based on user feedback."
+              "description": "CSV and PDF statements from CIBC Caribbean, Scotiabank Caribbean, Bank of The Bahamas, and Teachers & Salaried Workers Co-operative Credit Union (TSWCCUL) are normalized alongside manually tracked cash transactions. Support for additional institutions is prioritized and expanded based on user feedback."
             },
             {
               "icon": "database",

--- a/src/data/watch-videos.ts
+++ b/src/data/watch-videos.ts
@@ -87,7 +87,7 @@ export const watchVideos: WatchVideo[] = [
     title: 'Rainy Day v0.2.1',
     subtitle: "Don't Make Me Think: Guided Demo & Field Testing Updates",
     description:
-      'See how I applied Steve Krug’s Don’t Make Me Think principles after PostHog revealed a 77% onboarding drop-off, redesigning onboarding around a guided walkthrough that increased first-time product entry from 23% to 97% and full-product reach from 0% to 27% across 100+ demo users.',
+      'See how I applied Steve Krug’s Don’t Make Me Think principles after PostHog revealed a 44% onboarding drop-off, redesigning onboarding around a guided walkthrough that increased first-time product entry to 97% and full-product reach from 0% to 30% across 60+ real demo users.',
     category: 'build-log',
     collection: 'Software Demos',
     youtubeUrl: 'https://www.youtube.com/watch?v=G8AT6G2Vm_Q',

--- a/src/lib/badge-contexts.ts
+++ b/src/lib/badge-contexts.ts
@@ -137,6 +137,16 @@ export const technologyContexts: Record<string, BadgeContext> = {
     ],
     capabilitiesLabel: 'What It Does:',
   },
+  'React.js': {
+    title: 'React.js',
+    description: 'Component-based JavaScript library for building interactive user interfaces',
+    capabilities: [
+      'Building reusable interface components',
+      'Managing state-driven user experiences',
+      'Creating responsive web application surfaces',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
   TypeScript: {
     title: 'TypeScript',
     description: 'Strongly-typed JavaScript for enterprise-scale applications',
@@ -235,6 +245,16 @@ export const technologyContexts: Record<string, BadgeContext> = {
     ],
     capabilitiesLabel: 'What It Does:',
   },
+  'C++': {
+    title: 'C++',
+    description: 'Compiled programming language for performance-focused systems and applications',
+    capabilities: [
+      'Building performance-sensitive application logic',
+      'Working with memory, types, and low-level system behavior',
+      'Maintaining and modernizing established codebases',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
   FastAPI: {
     title: 'FastAPI',
     description: 'Modern Python web framework for building APIs',
@@ -314,6 +334,16 @@ export const technologyContexts: Record<string, BadgeContext> = {
       'Checking parser, persistence, and review flows across realistic inputs',
       'Catching regressions in CSV and PDF ingestion behavior',
       'Validating edge cases such as malformed rows, date parsing, and duplicate detection',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  Playwright: {
+    title: 'Playwright',
+    description: 'Browser automation framework for reliable end-to-end testing',
+    capabilities: [
+      'Testing user workflows across modern browsers',
+      'Validating responsive routes and interactive states',
+      'Capturing repeatable evidence for UI regressions',
     ],
     capabilitiesLabel: 'What It Does:',
   },
@@ -436,6 +466,37 @@ export const technologyContexts: Record<string, BadgeContext> = {
       'Keeping engineering execution aligned with product planning',
     ],
     capabilitiesLabel: 'What It Does:',
+  },
+  'Driver.js': {
+    title: 'Driver.js',
+    description: 'Lightweight library for contextual product tours and guided walkthroughs',
+    capabilities: [
+      'Highlighting interface elements with contextual guidance',
+      'Sequencing multi-step product tours',
+      'Helping first-time visitors learn product workflows',
+    ],
+    capabilitiesLabel: 'What It Does:',
+  },
+  Agile: {
+    title: 'Agile',
+    description:
+      'Iterative product-development approach centered on feedback and incremental delivery',
+    capabilities: [
+      'Breaking product work into reviewable increments',
+      'Adapting plans from stakeholder and user feedback',
+      'Keeping delivery aligned through regular team rituals',
+    ],
+    capabilitiesLabel: 'How It Works:',
+  },
+  'Pair Programming': {
+    title: 'Pair Programming',
+    description: 'Collaborative development practice where two engineers solve problems together',
+    capabilities: [
+      'Sharing implementation context in real time',
+      'Reviewing decisions while code is written',
+      'Unblocking teammates through collaborative debugging',
+    ],
+    capabilitiesLabel: 'How It Works:',
   },
   Mintlify: {
     title: 'Mintlify',

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -209,7 +209,7 @@ export function generateRainyDayVideoStructuredData() {
     '@id': `${seoConfig.url}/#rainy-day-v0-2-1-video`,
     name: "Don't Make Me Think: Guided Demo & Field Testing Updates",
     description:
-      'See how I applied Steve Krug’s Don’t Make Me Think principles after PostHog revealed a 77% onboarding drop-off, redesigning onboarding around a guided walkthrough that increased first-time product entry from 23% to 97% and full-product reach from 0% to 27% across 100+ demo users.',
+      'See how I applied Steve Krug’s Don’t Make Me Think principles after PostHog revealed a 44% onboarding drop-off, redesigning onboarding around a guided walkthrough that increased first-time product entry to 97% and full-product reach from 0% to 30% across 60+ real demo users.',
     thumbnailUrl: ['https://i.ytimg.com/vi/G8AT6G2Vm_Q/maxresdefault.jpg'],
     contentUrl: 'https://www.youtube.com/watch?v=G8AT6G2Vm_Q',
     embedUrl: 'https://www.youtube.com/embed/G8AT6G2Vm_Q',


### PR DESCRIPTION
# Pull Request

## Summary

Refreshes the Rainy Day portfolio story with the latest cleaned PostHog metrics and current guided-demo results. The update keeps visible content and structured metadata consistent while filling missing badge tooltip contexts for technologies already used across the site.

## Linear

- [[BBG-98](https://linear.app/gervonte/issue/BBG-98/feature-update-builtbygervontecom-with-latest-rainy-day-progress)](https://linear.app/gervonte/issue/BBG-98/feature-update-builtbygervontecom-with-latest-rainy-day-progress)

## Scope

- Updates Rainy Day metrics across featured content, professional experience, and SEO metadata.
- Clarifies the supported Caribbean financial institutions.
- Adds missing badge contexts for existing technologies and engineering practices.
- Does not redesign the homepage, change the Rainy Day application, or introduce new data flows.
- Does not replace the existing v0.2.1 screenshots, which already represent the guided-demo experience.

## Changes

- Replaced the outdated 77% onboarding drop-off with the cleaned 44% figure.
- Updated first-time product entry to 97%.
- Updated full-product reach to 30% across 60+ real demo users.
- Removed remaining references to 100+ demo users.
- Named the four supported Caribbean institutions in the Rainy Day case study.
- Added badge contexts for React.js, C++, Playwright, Driver.js, Agile, and Pair Programming.
- Kept visible walkthrough copy and structured video metadata synchronized.

## Testing

- [ ] pnpm dev (verified app starts with no errors)
- [ ] Verified UI in desktop
- [x] Verified navigation + routes work as expected
- [ ] Verified data flows / ingestion (not applicable; static portfolio content only)
- [x] Other manual testing:
  - TypeScript type-check passed.
  - ESLint passed.
  - Prettier formatting check passed.
  - Watch page checks passed.
  - `git diff --check` passed.

## Notes / Follow-ups
